### PR TITLE
Add offline banner and backoff

### DIFF
--- a/public/main.js
+++ b/public/main.js
@@ -3,12 +3,18 @@ import { start, stop, onData } from './api.js';
 import { GUI } from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
 
 const canvas = document.querySelector('canvas');
+const sampleBanner = document.getElementById('sample-banner');
 initGlobe(canvas);
 
 const prevPositions = new Map();
 
-onData(data => {
+onData((data, fromSample) => {
   updateFlights(data);
+  if (fromSample) {
+    sampleBanner.classList.remove('hidden');
+  } else {
+    sampleBanner.classList.add('hidden');
+  }
   for (const f of data) {
     const lon = f[5];
     const lat = f[6];


### PR DESCRIPTION
## Summary
- show banner when sample data is loaded
- retry API fetches with exponential backoff

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa1512a4c8330ba6e431bfd2eafe3