### PR TITLE
Add polling interval control

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ LICENSE
 ## 🎮 Controls & Offline Mode
 
 - Use the panel in the top‑right to toggle **Live** polling, adjust the
-  **Min/Max Alt** filters, and change **Point Size**.
+  **Min/Max Alt** filters, change **Point Size**, and set **Poll Interval**.
 - If the OpenSky API cannot be reached the app automatically loads
   `sample.json` and shows an "Offline demo" banner.
 
@@ -79,7 +79,9 @@ LICENSE
 | `OPENSKY_USERNAME` | Optional | Auth for higher rate limits (OpenSky account) |
 | `OPENSKY_PASSWORD` | Optional | 〃                                             |
 | `MAPBOX_TOKEN`     | Optional | If you swap globe → Mapbox basemap later |
-|
+| `POLL_INTERVAL`    | Optional | Default polling frequency in ms |
+
+Use `POLL_INTERVAL` to set the starting refresh rate for flight data.
 Set `OPENSKY_USERNAME` and `OPENSKY_PASSWORD` in your environment before
 launching the static server if you have an OpenSky account. You can also
 store them as **GitHub Secrets** to keep CI safe:

--- a/public/api.js
+++ b/public/api.js
@@ -8,6 +8,17 @@ let intervalId = null;
 let pollInterval = 10000;
 let usingSample = false;
 
+// load default interval from env then override with stored preference
+if (typeof process !== 'undefined' && process.env && process.env.POLL_INTERVAL) {
+  const envInt = parseInt(process.env.POLL_INTERVAL, 10);
+  if (!isNaN(envInt)) pollInterval = envInt;
+}
+
+if (typeof localStorage !== 'undefined') {
+  const storedInt = parseInt(localStorage.getItem('pollInterval'), 10);
+  if (!isNaN(storedInt)) pollInterval = storedInt;
+}
+
 /**
  * Register a callback to receive flight data.
  * @param {(data:Array, usingSample:boolean) => void} cb
@@ -57,11 +68,29 @@ async function fetchData() {
   }
 }
 
-export function start(interval = 10000) {
+export function start(interval = pollInterval) {
   pollInterval = interval;
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem('pollInterval', String(pollInterval));
+    } catch (e) {
+      /* ignore quota errors */
+    }
+  }
   stop();
   fetchData();
   intervalId = setInterval(fetchData, pollInterval);
+}
+
+export function setPollInterval(interval) {
+  const intVal = parseInt(interval, 10);
+  if (!isNaN(intVal) && intVal > 0) {
+    start(intVal);
+  }
+}
+
+export function getPollInterval() {
+  return pollInterval;
 }
 
 export function stop() {

--- a/public/main.js
+++ b/public/main.js
@@ -1,5 +1,5 @@
 import { initGlobe, updateFlights, setPointSize, setAltitudeFilter, render } from './globe.js';
-import { start, stop, onData } from './api.js';
+import { start, stop, onData, setPollInterval, getPollInterval } from './api.js';
 import { GUI } from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
 
 const canvas = document.querySelector('canvas');
@@ -21,7 +21,8 @@ const params = {
   altitudeMin: 0,
   altitudeMax: 20000,
   pointSize: 0.03,
-  live: true
+  live: true,
+  pollInterval: getPollInterval()
 };
 
 const gui = new GUI();
@@ -46,9 +47,13 @@ gui.add(params, 'altitudeMax', 0, 20000).name('Max Alt').onChange(() => {
   setAltitudeFilter(params.altitudeMin, params.altitudeMax);
 });
 
+gui.add(params, 'pollInterval', 1000, 60000, 1000).name('Poll (ms)').onChange(val => {
+  setPollInterval(val);
+});
+
 setAltitudeFilter(params.altitudeMin, params.altitudeMax);
 setPointSize(params.pointSize);
-start();
+setPollInterval(params.pollInterval);
 
 function renderLoop() {
   requestAnimationFrame(renderLoop);


### PR DESCRIPTION
## Summary
- expose polling interval for OpenSky fetch via `POLL_INTERVAL` env var
- remember selected poll interval in localStorage
- add dat.GUI slider to control polling frequency
- document the new option in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa152992c8330a0dc1fcec55790f0