### PR TITLE
Add service worker caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A real‑time, interactive **3‑D globe** that plots commercial flights fetched
 | **Instanced billboards**        | `THREE.InstancedMesh` keeps GPU draw‑calls low (≤ 2 × flightCount)                                   |
 | **Control panel**               | Altitude filter, play/pause, point‑size slider via `dat.GUI`                                         |
 | **Offline demo**                | `sample.json` snapshot loads automatically if the API is unreachable                                 |
+| **Service worker cache**        | Caches assets and API responses for smoother offline use                                            |
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -19,5 +19,12 @@
   <div id="sample-banner" class="hidden">Offline demo &ndash; using sample data</div>
   <canvas id="globe"></canvas>
   <script type="module" src="main.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('service-worker.js');
+      });
+    }
+  </script>
 </body>
 </html>

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,51 @@
+const CACHE_NAME = 'airspace-cache-v1';
+const API_URL = 'https://opensky-network.org/api/states/all';
+const OFFLINE_ASSETS = [
+  './',
+  './index.html',
+  './style.css',
+  './main.js',
+  './globe.js',
+  './api.js',
+  './utils.js',
+  './sample.json',
+  './assets/plane.svg'
+];
+
+self.addEventListener('install', event => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then(cache => cache.addAll(OFFLINE_ASSETS))
+  );
+});
+
+self.addEventListener('activate', event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(keys.filter(k => k !== CACHE_NAME).map(k => caches.delete(k)))
+    )
+  );
+});
+
+self.addEventListener('fetch', event => {
+  const url = new URL(event.request.url);
+
+  if (url.href === API_URL) {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then(c => c.put(event.request, clone));
+          return response;
+        })
+        .catch(() => caches.match(event.request))
+        .then(resp => resp || caches.match('./sample.json'))
+    );
+    return;
+  }
+
+  if (url.origin === location.origin) {
+    event.respondWith(
+      caches.match(event.request).then(resp => resp || fetch(event.request))
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- add service worker to cache assets and API data
- register service worker in `index.html`
- mention service worker cache in project README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa1532854833099a4aa3c8d15b0a4