### PR TITLE
Add logger module

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ LICENSE
 | `OPENSKY_USERNAME` | Optional | Auth for higher rate limits (OpenSky account) |
 | `OPENSKY_PASSWORD` | Optional | 〃                                             |
 | `MAPBOX_TOKEN`     | Optional | If you swap globe → Mapbox basemap later |
+| `SENTRY_DSN`       | Optional | Enable error reporting via Sentry         |
 |
 Set `OPENSKY_USERNAME` and `OPENSKY_PASSWORD` in your environment before
 launching the static server if you have an OpenSky account. You can also

--- a/public/api.js
+++ b/public/api.js
@@ -1,4 +1,5 @@
 // Data fetching and polling utilities for OpenSky API
+import { log, error as logError } from './logger.js';
 
 const API_URL = 'https://opensky-network.org/api/states/all';
 const SAMPLE_URL = 'sample.json';
@@ -39,10 +40,11 @@ async function fetchData() {
     const states = Array.isArray(json.states) ? json.states : [];
     const filtered = states.filter(s => s[5] != null && s[6] != null).slice(0, 5000);
     notify(filtered);
+    log('Fetched live flight data');
     return;
   } catch (err) {
     // fall back to sample data on failure
-    console.error('OpenSky fetch failed, using sample', err);
+    logError(err, { msg: 'OpenSky fetch failed, using sample' });
   }
 
   try {
@@ -52,8 +54,9 @@ async function fetchData() {
     const states = Array.isArray(json.states) ? json.states : [];
     const filtered = states.filter(s => s[5] != null && s[6] != null);
     notify(filtered);
+    log('Loaded sample flight data');
   } catch (err) {
-    console.error('Failed to load sample data', err);
+    logError(err, { msg: 'Failed to load sample data' });
   }
 }
 
@@ -62,12 +65,14 @@ export function start(interval = 10000) {
   stop();
   fetchData();
   intervalId = setInterval(fetchData, pollInterval);
+  log('Polling started');
 }
 
 export function stop() {
   if (intervalId) {
     clearInterval(intervalId);
     intervalId = null;
+    log('Polling stopped');
   }
 }
 

--- a/public/index.html
+++ b/public/index.html
@@ -14,6 +14,7 @@
     }
   }
   </script>
+  <!-- Define SENTRY_DSN in a preceding script tag to enable error reporting -->
 </head>
 <body>
   <div id="sample-banner" class="hidden">Offline demo &ndash; using sample data</div>

--- a/public/logger.js
+++ b/public/logger.js
@@ -1,0 +1,29 @@
+let sentry = null;
+
+/**
+ * Initialises the logger. Pass a Sentry DSN to enable reporting.
+ *
+ * @param {{dsn?: string}} [opts]
+ */
+export function init(opts = {}) {
+  if (opts.dsn && window.Sentry) {
+    window.Sentry.init({ dsn: opts.dsn });
+    sentry = window.Sentry;
+  }
+}
+
+/** Log a normal message. */
+export function log(message, data) {
+  console.log('[LOG]', message, data ?? '');
+  if (sentry) {
+    sentry.captureMessage(message, { level: 'info', extra: data });
+  }
+}
+
+/** Log an error. */
+export function error(err, data) {
+  console.error('[ERROR]', err, data ?? '');
+  if (sentry) {
+    sentry.captureException(err, { extra: data });
+  }
+}

--- a/public/main.js
+++ b/public/main.js
@@ -1,6 +1,9 @@
 import { initGlobe, updateFlights, setPointSize, setAltitudeFilter, render } from './globe.js';
 import { start, stop, onData } from './api.js';
+import { init as initLogger, log } from './logger.js';
 import { GUI } from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
+
+initLogger({ dsn: window.SENTRY_DSN });
 
 const canvas = document.querySelector('canvas');
 initGlobe(canvas);
@@ -28,8 +31,10 @@ const gui = new GUI();
 
 gui.add(params, 'live').name('Live').onChange(val => {
   if (val) {
+    log('Polling started');
     start();
   } else {
+    log('Polling stopped');
     stop();
   }
 });
@@ -48,6 +53,7 @@ gui.add(params, 'altitudeMax', 0, 20000).name('Max Alt').onChange(() => {
 
 setAltitudeFilter(params.altitudeMin, params.altitudeMax);
 setPointSize(params.pointSize);
+log('Visualizer initialised');
 start();
 
 function renderLoop() {


### PR DESCRIPTION
## Summary
- add a simple `logger.js` with optional Sentry support
- initialise the logger in `main.js`
- log start/stop events while polling
- log fetch errors in `api.js`
- document new `SENTRY_DSN` config option and update HTML comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa158452c8330bae71390222ec215