### PR TITLE
Add credential security documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,19 @@ launching the static server if you have an OpenSky account. You can also
 store them as **GitHub Secrets** to keep CI safe:
 `Settings → Secrets → Actions → New repository secret`.
 
+### Credential Security
+
+- **Never commit your credentials**. The `.gitignore` already excludes
+  `.env` files so you can keep `OPENSKY_USERNAME` and
+  `OPENSKY_PASSWORD` locally without risk.
+- **Use a `.env` file for local development** and load it with a tool
+  like `dotenv` if you migrate to a Node backend.
+- **Store secrets in GitHub** under **Settings → Secrets** when using
+  Actions or any CI workflow.
+- **Avoid logging sensitive values**. Check that no
+  `console.log()` or build script prints your OpenSky username or
+  password to stdout or CI logs.
+
 ---
 
 ## 🧪 Development Workflow

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Credential Security Guide
+
+This short document explains how to keep your OpenSky Network username
+and password safe when working with this project.
+
+1. **Use environment variables** – Place `OPENSKY_USERNAME` and
+   `OPENSKY_PASSWORD` in a `.env` file or your shell profile.
+   The repository's `.gitignore` already excludes `.env` files.
+2. **Use GitHub Secrets for CI** – Navigate to *Settings → Secrets*
+   and create secrets so automated workflows can access credentials
+   without storing them in the repo.
+3. **Never log credentials** – Audit your code and build scripts to make
+   sure no `console.log()` or debug output contains the username or
+   password. Review CI logs as well.
+
+Following these steps helps prevent accidental leaks and keeps your
+access to the OpenSky API secure.
+


### PR DESCRIPTION
## Summary
- document how to store OpenSky credentials securely
- add dedicated credential security guide

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa15d463c83308d1dd069cb809e51