### PR TITLE
Add semantic version release workflow

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,9 @@
+# GitHub Config
+
+This folder contains settings for GitHub, including workflows for automatic releases.
+
+Demo: run `./demo.sh` to print a message.
+
+--
+Author: Codex Bot
+Date: 2025-05-31

--- a/.github/demo.sh
+++ b/.github/demo.sh
@@ -1,0 +1,1 @@
+echo "GitHub config demo"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,7 @@
+# Workflow Files
+
+This folder stores GitHub Actions workflows.
+The demo workflow `release.yml` publishes semantic releases.
+
+Author: Codex Bot
+Date: 2025-05-31

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,15 @@
+name: Release
+on:
+  push:
+    branches: [main]
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run release
+      - run: git push --follow-tags origin main

--- a/README.md
+++ b/README.md
@@ -115,6 +115,10 @@ pnpm run test        # jest
 
 Contributions & PRs welcome!  Please open an issue first to discuss major changes.
 
+## Release Management
+Run `npm run release` to generate a changelog, bump the version, and create a Git tag.
+
+
 ---
 
 ## 📜 License

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "Airspace Live Visualizer",
   "type": "module",
   "scripts": {
-    "test": "echo \"No test specified\" && exit 0"
+    "test": "echo \"No test specified\" && exit 0",
+    "release": "standard-version"
+  },
+  "devDependencies": {
+    "standard-version": "^9.5.0"
   }
 }


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to publish semantic releases
- document how to trigger releases
- add `standard-version` and release script
- include required README and demo files for `.github` folders

## Testing
- `npm test`
- `bash .github/demo.sh`


------
https://chatgpt.com/codex/tasks/task_e_683aa160682883308cbd08c9d7f971ce