### PR TITLE
Add dev performance overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ pnpm install         # add eslint, prettier, jest as devDeps
 pnpm run dev         # (optional) vite dev server if you migrate to a build
 ```
 
+Dev mode can be toggled by appending `?dev` to the URL; this displays real-time FPS and update timings.
+
 ### Lint & Test (optional)
 
 ```bash

--- a/public/main.js
+++ b/public/main.js
@@ -2,13 +2,37 @@ import { initGlobe, updateFlights, setPointSize, setAltitudeFilter, render } fro
 import { start, stop, onData } from './api.js';
 import { GUI } from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
 
+const DEV_MODE = location.hostname === 'localhost' || location.search.includes('dev');
+
+let fpsDiv;
+let updateDiv;
+let fps = 0;
+let frameCount = 0;
+let lastFrame = performance.now();
+let lastUpdate = 0;
+
+if (DEV_MODE) {
+  const stats = document.createElement('div');
+  stats.id = 'stats';
+  fpsDiv = document.createElement('div');
+  updateDiv = document.createElement('div');
+  stats.appendChild(fpsDiv);
+  stats.appendChild(updateDiv);
+  document.body.appendChild(stats);
+}
+
 const canvas = document.querySelector('canvas');
 initGlobe(canvas);
 
 const prevPositions = new Map();
 
 onData(data => {
+  const t0 = performance.now();
   updateFlights(data);
+  lastUpdate = performance.now() - t0;
+  if (DEV_MODE && updateDiv) {
+    updateDiv.textContent = `update: ${lastUpdate.toFixed(1)} ms`;
+  }
   for (const f of data) {
     const lon = f[5];
     const lat = f[6];
@@ -52,6 +76,16 @@ start();
 
 function renderLoop() {
   requestAnimationFrame(renderLoop);
+  const now = performance.now();
+  frameCount++;
+  if (now - lastFrame >= 1000) {
+    fps = (frameCount * 1000) / (now - lastFrame);
+    frameCount = 0;
+    lastFrame = now;
+    if (DEV_MODE && fpsDiv) {
+      fpsDiv.textContent = `fps: ${fps.toFixed(1)}`;
+    }
+  }
   render();
 }
 

--- a/public/style.css
+++ b/public/style.css
@@ -43,3 +43,14 @@ body {
   font-size: 12px;
   border-radius: 2px;
 }
+
+#stats {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  padding: 2px 4px;
+  background: rgba(0, 0, 0, 0.5);
+  color: #0f0;
+  font-size: 0.8em;
+  z-index: 10;
+}


### PR DESCRIPTION
## Summary
- instrument `updateFlights` to log update time
- calculate FPS each second in the render loop
- show FPS and update timing overlay when running with `?dev`
- document dev mode in the README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa1644d808330b150a8c2044b6e45