### PR TITLE
Implement basic i18n support

### DIFF
--- a/demo.sh
+++ b/demo.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+npx serve public -l 8000

--- a/public/README.md
+++ b/public/README.md
@@ -1,0 +1,11 @@
+# public
+
+Static client application. Serve this folder with any static server to view the live flight demo.
+
+```bash
+npx serve . -l 8000
+```
+
+Open <http://localhost:8000> in your browser.
+
+© 2025 David Martinez

--- a/public/assets/README.md
+++ b/public/assets/README.md
@@ -1,0 +1,6 @@
+# assets
+
+Plane icon used in the main demo.
+Open `demo.html` to view it in isolation.
+
+© 2025 David Martinez

--- a/public/assets/demo.html
+++ b/public/assets/demo.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Plane Icon Demo</title>
+</head>
+<body>
+  <img src="plane.svg" alt="plane">
+</body>
+</html>

--- a/public/i18n.js
+++ b/public/i18n.js
@@ -1,0 +1,18 @@
+let strings = {};
+
+export async function loadLocale() {
+  const lang = (navigator.language || 'en').slice(0, 2).toLowerCase();
+  const file = `strings-${lang}.json`;
+  try {
+    const res = await fetch(file);
+    if (!res.ok) throw new Error('locale missing');
+    strings = await res.json();
+  } catch (e) {
+    const res = await fetch('strings-en.json');
+    strings = await res.json();
+  }
+}
+
+export function t(key) {
+  return strings[key] || key;
+}

--- a/public/index.html
+++ b/public/index.html
@@ -16,7 +16,7 @@
   </script>
 </head>
 <body>
-  <div id="sample-banner" class="hidden">Offline demo &ndash; using sample data</div>
+  <div id="sample-banner" class="hidden"></div>
   <canvas id="globe"></canvas>
   <script type="module" src="main.js"></script>
 </body>

--- a/public/main.js
+++ b/public/main.js
@@ -1,14 +1,21 @@
 import { initGlobe, updateFlights, setPointSize, setAltitudeFilter, render } from './globe.js';
 import { start, stop, onData } from './api.js';
 import { GUI } from 'https://cdn.jsdelivr.net/npm/dat.gui@0.7.9/build/dat.gui.module.js';
+import { loadLocale, t } from './i18n.js';
 
 const canvas = document.querySelector('canvas');
+await loadLocale();
+document.title = t('title');
+const banner = document.getElementById('sample-banner');
+banner.textContent = t('offlineBanner');
 initGlobe(canvas);
 
 const prevPositions = new Map();
 
-onData(data => {
+onData((data, sample) => {
   updateFlights(data);
+  if (sample) banner.classList.remove('hidden');
+  else banner.classList.add('hidden');
   for (const f of data) {
     const lon = f[5];
     const lat = f[6];
@@ -26,7 +33,7 @@ const params = {
 
 const gui = new GUI();
 
-gui.add(params, 'live').name('Live').onChange(val => {
+gui.add(params, 'live').name(t('live')).onChange(val => {
   if (val) {
     start();
   } else {
@@ -34,15 +41,15 @@ gui.add(params, 'live').name('Live').onChange(val => {
   }
 });
 
-gui.add(params, 'pointSize', 0.01, 1).name('Point Size').onChange(value => {
+gui.add(params, 'pointSize', 0.01, 1).name(t('pointSize')).onChange(value => {
   setPointSize(value);
 });
 
-gui.add(params, 'altitudeMin', 0, 20000).name('Min Alt').onChange(() => {
+gui.add(params, 'altitudeMin', 0, 20000).name(t('minAlt')).onChange(() => {
   setAltitudeFilter(params.altitudeMin, params.altitudeMax);
 });
 
-gui.add(params, 'altitudeMax', 0, 20000).name('Max Alt').onChange(() => {
+gui.add(params, 'altitudeMax', 0, 20000).name(t('maxAlt')).onChange(() => {
   setAltitudeFilter(params.altitudeMin, params.altitudeMax);
 });
 

--- a/public/strings-en.json
+++ b/public/strings-en.json
@@ -1,0 +1,8 @@
+{
+  "title": "Airspace Live Visualizer",
+  "offlineBanner": "Offline demo – using sample data",
+  "live": "Live",
+  "pointSize": "Point Size",
+  "minAlt": "Min Alt",
+  "maxAlt": "Max Alt"
+}

--- a/public/strings-es.json
+++ b/public/strings-es.json
@@ -1,0 +1,8 @@
+{
+  "title": "Visualizador de Tráfico Aéreo",
+  "offlineBanner": "Demo sin conexión – usando datos de muestra",
+  "live": "En vivo",
+  "pointSize": "Tamaño de puntos",
+  "minAlt": "Alt Min",
+  "maxAlt": "Alt Max"
+}


### PR DESCRIPTION
## Summary
- add new i18n loader and translation strings
- translate main GUI labels and offline banner
- include minimal README and demo files per folder
- provide simple `demo.sh` to run the project

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa16707288330b0648a1656ba3d24