### PR TITLE
Add observable store for flights and UI settings

### DIFF
--- a/public/store.js
+++ b/public/store.js
@@ -1,0 +1,29 @@
+export function createStore(initialState = {}) {
+  let state = { ...initialState };
+  const listeners = new Set();
+
+  const getState = () => state;
+
+  const setState = update => {
+    state = { ...state, ...update };
+    listeners.forEach(fn => fn(state));
+  };
+
+  const subscribe = fn => {
+    listeners.add(fn);
+    return () => listeners.delete(fn);
+  };
+
+  return { getState, setState, subscribe };
+}
+
+export const store = createStore({
+  flights: [],
+  usingSample: false,
+  settings: {
+    altitudeMin: 0,
+    altitudeMax: 20000,
+    pointSize: 0.03,
+    live: true
+  }
+});


### PR DESCRIPTION
## Summary
- introduce a small observable store
- use the store in the main module to manage flights and UI settings
- update GUI callbacks to dispatch to the store

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683aa16791508330b4da79bc501b6f70